### PR TITLE
Refactor credential and API key handling

### DIFF
--- a/src/GmailWrapper.php
+++ b/src/GmailWrapper.php
@@ -16,7 +16,7 @@ class GmailWrapper
      * Returns an authorized API client.
      * @return \Google\Client the authorized client object
      */
-    public static function getClient(array $clientsecret_data, array $apitoken_data)
+    public static function getClient(array $authConfig, array $apitoken_data)
     {
         $logger = new Logger("GoogleAPI");
 
@@ -28,7 +28,7 @@ class GmailWrapper
         $client = new \Google\Client();
         $client->setApplicationName('MyCFApp');
         $client->setScopes($SCOPES);
-        $client->setAuthConfig($clientsecret_data);
+        $client->setAuthConfig($authConfig);
         $client->setAccessType('offline');
         $client->setPrompt('select_account consent');
         // $client->setRedirectUri('https://www.google.com/');

--- a/src/GmailWrapper.php
+++ b/src/GmailWrapper.php
@@ -16,7 +16,7 @@ class GmailWrapper
      * Returns an authorized API client.
      * @return \Google\Client the authorized client object
      */
-    public static function getClient(string $clientsecret_path, string $apitoken_path)
+    public static function getClient(array $clientsecret_data, array $apitoken_data)
     {
         $logger = new Logger("GoogleAPI");
 
@@ -28,7 +28,7 @@ class GmailWrapper
         $client = new \Google\Client();
         $client->setApplicationName('MyCFApp');
         $client->setScopes($SCOPES);
-        $client->setAuthConfig($clientsecret_path);
+        $client->setAuthConfig($clientsecret_data);
         $client->setAccessType('offline');
         $client->setPrompt('select_account consent');
         // $client->setRedirectUri('https://www.google.com/');
@@ -38,11 +38,7 @@ class GmailWrapper
         // created automatically when the authorization flow completes for the first
         // time.
         // https://sqripts.com/2022/08/25/20386/
-        if (file_exists($apitoken_path)) {
-            $logger->log("token file exists");
-            $accessToken = json_decode(file_get_contents($apitoken_path), true);
-            $client->setAccessToken($accessToken);
-        }
+        $client->setAccessToken($apitoken_data);
 
         // If there is no previous token or it's expired.
         if ($client->isAccessTokenExpired()) {
@@ -55,11 +51,6 @@ class GmailWrapper
                 // ★THIS DOESNT WORK. use hello_gmail/create_refresh_token instead
                 throw new \Exception("THIS DOESN'T WORK");
             }
-            // Save the token to a file.
-            if (!file_exists(dirname($apitoken_path))) {
-                mkdir(dirname($apitoken_path), 0700, true);
-            }
-            file_put_contents($apitoken_path, json_encode($client->getAccessToken()));
         }
         return $client;
     }

--- a/src/Gpt.php
+++ b/src/Gpt.php
@@ -11,15 +11,11 @@ use \GuzzleHttp\Client;
  */
 class Gpt
 {
-    private string $secret;
     private Client $client;
 
-    public function __construct(string $openai_api_key, private string $model)
+    public function __construct(private string $openaiApiKey, private string $model)
     {
-        $this->secret = $openai_api_key;
         // debug!!
-        $logger = new Logger();
-        $logger->log("api: " . $this->secret);
         $this->client = new Client();
     }
 
@@ -47,7 +43,7 @@ class Gpt
             [
                 'headers' => [
                     'Content-Type' => 'application/json',
-                    'Authorization' => "Bearer {$this->secret}",
+                    'Authorization' => "Bearer {$this->openaiApiKey}",
                 ],
                 'body' => json_encode($payload),
             ]

--- a/src/Gpt.php
+++ b/src/Gpt.php
@@ -14,9 +14,9 @@ class Gpt
     private string $secret;
     private Client $client;
 
-    public function __construct(private string $model)
+    public function __construct(private string $model, string $openai_api_key)
     {
-        $this->secret = getenv('OPENAI_API_KEY');
+        $this->secret = $openai_api_key;
         // debug!!
         $logger = new Logger();
         $logger->log("api: " . $this->secret);

--- a/src/Gpt.php
+++ b/src/Gpt.php
@@ -14,7 +14,7 @@ class Gpt
     private string $secret;
     private Client $client;
 
-    public function __construct(private string $model, string $openai_api_key)
+    public function __construct(string $openai_api_key, private string $model)
     {
         $this->secret = $openai_api_key;
         // debug!!

--- a/src/Line.php
+++ b/src/Line.php
@@ -11,11 +11,10 @@ class Line
     private array $tokens;
     private array $presetTargetIds;
 
-    public function __construct(string $configPath)
+    public function __construct(array $tokens, array $presetTargetIds)
     {
-        $config = Utils::getConfig($configPath);
-        $this->tokens = $config["tokens"];
-        $this->presetTargetIds = $config["target_ids"];
+        $this->tokens = $tokens;
+        $this->presetTargetIds = $presetTargetIds;
     }
 
     /** 

--- a/src/Line.php
+++ b/src/Line.php
@@ -8,13 +8,9 @@ use Exception;
 
 class Line
 {
-    private array $tokens;
-    private array $presetTargetIds;
 
-    public function __construct(array $tokens, array $presetTargetIds)
+    public function __construct(private array $tokens, private array $presetTargetIds)
     {
-        $this->tokens = $tokens;
-        $this->presetTargetIds = $presetTargetIds;
     }
 
     /** 

--- a/src/Pocket.php
+++ b/src/Pocket.php
@@ -6,13 +6,8 @@ namespace yananob\MyTools;
 
 class Pocket
 {
-    private string $consumer_key;
-    private string $access_token;
-
-    public function __construct(string $consumer_key, string $access_token)
+    public function __construct(private string $consumer_key, private string $access_token)
     {
-        $this->consumer_key = $consumer_key;
-        $this->access_token = $access_token;
     }
 
     public function add(string $url)

--- a/src/Pocket.php
+++ b/src/Pocket.php
@@ -9,11 +9,10 @@ class Pocket
     private string $consumer_key;
     private string $access_token;
 
-    public function __construct(string $configPath)
+    public function __construct(string $consumer_key, string $access_token)
     {
-        $config = Utils::getConfig($configPath);
-        $this->consumer_key = $config["consumer_key"];
-        $this->access_token = $config["access_token"];
+        $this->consumer_key = $consumer_key;
+        $this->access_token = $access_token;
     }
 
     public function add(string $url)

--- a/src/Raindrop.php
+++ b/src/Raindrop.php
@@ -10,13 +10,11 @@ use GuzzleHttp\Exception\RequestException;
 
 class Raindrop
 {
-    private string $accessToken;
     private string $apiEndpoint = 'https://api.raindrop.io/rest/v1/raindrop'; // Default API endpoint
     private ClientInterface $client;
 
-    public function __construct(string $accessToken, ?string $apiEndpoint = null, ClientInterface $client = null)
+    public function __construct(private string $accessToken, ?string $apiEndpoint = null, ClientInterface $client = null)
     {
-        $this->accessToken = $accessToken;
         if ($apiEndpoint !== null) {
             $this->apiEndpoint = $apiEndpoint;
         }

--- a/src/Raindrop.php
+++ b/src/Raindrop.php
@@ -14,16 +14,11 @@ class Raindrop
     private string $apiEndpoint = 'https://api.raindrop.io/rest/v1/raindrop'; // Default API endpoint
     private ClientInterface $client;
 
-    public function __construct(string $configPath, ClientInterface $client = null)
+    public function __construct(string $accessToken, ?string $apiEndpoint = null, ClientInterface $client = null)
     {
-        $config = Utils::getConfig($configPath);
-        if (!isset($config['access_token'])) {
-            throw new \InvalidArgumentException('Access token not found in Raindrop config.');
-        }
-        $this->accessToken = $config['access_token'];
-        // Allow overriding API endpoint from config for testing or future API versions
-        if (isset($config['api_endpoint'])) {
-            $this->apiEndpoint = $config['api_endpoint'];
+        $this->accessToken = $accessToken;
+        if ($apiEndpoint !== null) {
+            $this->apiEndpoint = $apiEndpoint;
         }
         $this->client = $client ?? new Client();
     }

--- a/tests/GptTest.php
+++ b/tests/GptTest.php
@@ -9,7 +9,7 @@ class GptTest extends TestCase
 {
     public function testGetAnswer(): void
     {
-        $gpt = new Gpt("gpt-4.1");
+        $gpt = new Gpt("gpt-4.1", "dummy_api_key");
 
         $answer = $gpt->getAnswer("あなたは日本のコメディアンです。", "自己紹介をしてください。");
         $this->assertNotEmpty($answer);

--- a/tests/GptTest.php
+++ b/tests/GptTest.php
@@ -9,7 +9,7 @@ class GptTest extends TestCase
 {
     public function testGetAnswer(): void
     {
-        $gpt = new Gpt("gpt-4.1", "dummy_api_key");
+        $gpt = new Gpt("dummy_api_key", "gpt-4.1");
 
         $answer = $gpt->getAnswer("あなたは日本のコメディアンです。", "自己紹介をしてください。");
         $this->assertNotEmpty($answer);

--- a/tests/LineTest.php
+++ b/tests/LineTest.php
@@ -9,7 +9,9 @@ class LineTest extends TestCase
 {
     public function testSendMessage(): void
     {
-        $line = new Line(__DIR__ . "/configs/line.json");
+        $tokens = ["test" => "testTOKEN"];
+        $targetIds = ["test" => "testID"];
+        $line = new Line($tokens, $targetIds);
         $line->sendPush(
             bot: "test",
             target: "test",
@@ -20,7 +22,9 @@ class LineTest extends TestCase
 
     public function testGetTargets(): void
     {
-        $line = new Line(__DIR__ . "/configs/line_dummy.json");
+        $tokens = ["hoge1" => "hoge1TOKEN", "hoge2" => "hoge2TOKEN", "__EOF__" => ""];
+        $targetIds = ["hoge1" => "hoge1ID", "hoge2" => "hoge2ID", "__MEMO__" => "ここにグループIDやユーザーIDを指定", "__EOF__" => ""];
+        $line = new Line($tokens, $targetIds);
         $this->assertEquals(
             ["hoge1", "hoge2"],
             $line->getTargets()

--- a/tests/RaindropTest.php
+++ b/tests/RaindropTest.php
@@ -16,45 +16,15 @@ use GuzzleHttp\Exception\RequestException;
 
 class RaindropTest extends TestCase
 {
-    private string $sampleConfigPath = __DIR__ . '/configs/raindrop.test.json';
     private array $sampleConfig = [
         'access_token' => 'test_token',
         'api_endpoint' => 'https://api.example.com/v1/raindrop'
     ];
 
-    protected function setUp(): void
-    {
-        // Create a dummy config file for testing
-        if (!is_dir(__DIR__ . '/configs')) {
-            mkdir(__DIR__ . '/configs');
-        }
-        file_put_contents($this->sampleConfigPath, json_encode($this->sampleConfig));
-    }
-
-    protected function tearDown(): void
-    {
-        // Clean up the dummy config file
-        if (file_exists($this->sampleConfigPath)) {
-            unlink($this->sampleConfigPath);
-        }
-        if (is_dir(__DIR__ . '/configs') && count(scandir(__DIR__ . '/configs')) == 2) { // . and ..
-            rmdir(__DIR__ . '/configs');
-        }
-    }
-
     public function testConstructorLoadsConfig(): void
     {
-        $raindrop = new Raindrop($this->sampleConfigPath);
+        $raindrop = new Raindrop($this->sampleConfig['access_token'], $this->sampleConfig['api_endpoint']);
         $this->assertInstanceOf(Raindrop::class, $raindrop);
-    }
-
-    public function testConstructorThrowsExceptionIfAccessTokenMissing(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Access token not found in Raindrop config.');
-        $badConfig = ['api_endpoint' => 'https://api.example.com/v1/raindrop'];
-        file_put_contents($this->sampleConfigPath, json_encode($badConfig));
-        new Raindrop($this->sampleConfigPath);
     }
 
     public function testAddSuccessfully(): void
@@ -65,7 +35,7 @@ class RaindropTest extends TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack, 'base_uri' => $this->sampleConfig['api_endpoint']]); // Added base_uri to ensure mock is hit
 
-        $raindrop = new Raindrop($this->sampleConfigPath, $client);
+        $raindrop = new Raindrop($this->sampleConfig['access_token'], $this->sampleConfig['api_endpoint'], $client);
         $response = $raindrop->add('http://example.com');
 
         $this->assertTrue($response['result']);
@@ -86,7 +56,7 @@ class RaindropTest extends TestCase
         // Ensure Guzzle does not throw its own exception for 500, so our custom logic is hit
         $client = new Client(['handler' => $handlerStack, 'base_uri' => $this->sampleConfig['api_endpoint'], 'http_errors' => false]);
 
-        $raindrop = new Raindrop($this->sampleConfigPath, $client);
+        $raindrop = new Raindrop($this->sampleConfig['access_token'], $this->sampleConfig['api_endpoint'], $client);
         $raindrop->add('http://example.com/fail');
     }
     
@@ -101,7 +71,7 @@ class RaindropTest extends TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack, 'base_uri' => $this->sampleConfig['api_endpoint']]);
 
-        $raindrop = new Raindrop($this->sampleConfigPath, $client);
+        $raindrop = new Raindrop($this->sampleConfig['access_token'], $this->sampleConfig['api_endpoint'], $client);
         $raindrop->add('http://example.com/guzzle-fail');
     }
 }


### PR DESCRIPTION
This commit modifies several classes to accept credentials and API keys as direct arguments to their constructors or relevant methods, instead of you reading them from configuration files or environment variables.

The following classes were updated:
- GmailWrapper: `getClient` now accepts client secret and API token data as arrays.
- Gpt: Constructor now accepts the OpenAI API key.
- Line: Constructor now accepts tokens and preset target ID arrays.
- Pocket: Constructor now accepts consumer key and access token.
- Raindrop: Constructor now accepts access token and API endpoint.

Unit tests for Gpt, Line, and Raindrop have been updated to reflect these changes, passing dummy data directly to the constructors.

The `Utils::getConfig` method was reviewed and left unchanged as it serves general file/JSON reading purposes beyond just credential loading.

This change aims to provide more flexibility in how you manage and supply credentials to these services.