### PR TITLE
Refactor: Use DI for HTTP clients in Gpt and Line classes

### DIFF
--- a/src/Gpt.php
+++ b/src/Gpt.php
@@ -13,10 +13,9 @@ class Gpt
 {
     private Client $client;
 
-    public function __construct(private string $openaiApiKey, private string $model)
+    public function __construct(private string $openaiApiKey, private string $model, ?Client $client = null)
     {
-        // debug!!
-        $this->client = new Client();
+        $this->client = $client ?? new Client();
     }
 
     public function getAnswer(string $context, string $message): string

--- a/tests/GptTest.php
+++ b/tests/GptTest.php
@@ -4,14 +4,29 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use yananob\MyTools\Gpt;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
 
 class GptTest extends TestCase
 {
     public function testGetAnswer(): void
     {
-        $gpt = new Gpt("dummy_api_key", "gpt-4.1");
+        // Create a mock handler
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'choices' => [
+                    ['message' => ['content' => 'Mocked answer']]
+                ]
+            ]))
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $gpt = new Gpt("dummy_api_key", "gpt-4.1", $client);
 
         $answer = $gpt->getAnswer("あなたは日本のコメディアンです。", "自己紹介をしてください。");
-        $this->assertNotEmpty($answer);
+        $this->assertEquals("Mocked answer", $answer);
     }
 }

--- a/tests/LineTest.php
+++ b/tests/LineTest.php
@@ -4,26 +4,39 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use yananob\MyTools\Line;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
 
 class LineTest extends TestCase
 {
     public function testSendMessage(): void
     {
+        // Create a mock handler
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([])) // Simulate a successful API call
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
         $tokens = ["test" => "testTOKEN"];
         $targetIds = ["test" => "testID"];
-        $line = new Line($tokens, $targetIds);
+        $line = new Line($tokens, $targetIds, $client);
         $line->sendPush(
             bot: "test",
             target: "test",
             message: "[LineTest] Sent by Messaging API!",
         );
-        $this->assertTrue(true);
+        $this->assertTrue(true); // Assertion remains the same as the original test
     }
 
     public function testGetTargets(): void
     {
         $tokens = ["hoge1" => "hoge1TOKEN", "hoge2" => "hoge2TOKEN", "__EOF__" => ""];
         $targetIds = ["hoge1" => "hoge1ID", "hoge2" => "hoge2ID", "__MEMO__" => "ここにグループIDやユーザーIDを指定", "__EOF__" => ""];
+
+        // testGetTargets does not involve API calls, so no need to mock the client here.
         $line = new Line($tokens, $targetIds);
         $this->assertEquals(
             ["hoge1", "hoge2"],


### PR DESCRIPTION
- Modified Gpt and Line classes to accept an HTTP client via their constructors, allowing for mock clients to be injected during tests.
- Updated GptTest and LineTest to inject mock Guzzle clients with predefined responses, preventing actual API calls during testing.
- This resolves previous test failures due to authentication errors and improves testability by decoupling classes from concrete HTTP client implementations.